### PR TITLE
chore: enabling npm provenance integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      id-token: write
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
@@ -29,4 +30,4 @@ jobs:
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}
           optic-token: ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] || secrets.OPTIC_TOKEN }}
           build-command: npm ci
-
+          provenance: true


### PR DESCRIPTION
- Resolves #264  
- Enabling NPM Provenance beta integration when publishing new versions to NPM.
- Resolves partially https://github.com/nearform/hub-draft-issues/issues/247