### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "graphiql": "^3.0.0",
         "graphql": "^16.6.0",
-        "husky": "^8.0.1",
+        "husky": "^9.0.11",
         "jest": "^29.2.2",
         "jest-environment-jsdom": "^29.2.2",
         "lint-staged": "^15.0.1",
@@ -11115,15 +11115,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -26679,9 +26679,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "vite build",
     "test": "jest --setupFilesAfterEnv ./src/setupTests.js",
     "test:ci": "cross-env CI=true npm test",
-    "prepare": "husky install",
+    "prepare": "husky",
     "lint": "eslint src/**/*.jsx",
     "lint:fix": "eslint --fix",
     "prepublish": "npm run build"
@@ -57,7 +57,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "graphiql": "^3.0.0",
     "graphql": "^16.6.0",
-    "husky": "^8.0.1",
+    "husky": "^9.0.11",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",
     "lint-staged": "^15.0.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)